### PR TITLE
Add dateLabel option to show end date on timeline bars

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "planner",
   "name": "Planner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "minAppVersion": "1.10.0",
   "description": "Unified calendar, kanban, timeline, and task list for project and time management.",
   "author": "Sawyer Rensel",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "planner",
   "name": "Planner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "minAppVersion": "1.10.0",
   "description": "Unified calendar, kanban, timeline, and task list for project and time management.",
   "author": "Sawyer Rensel",

--- a/src/services/MarkwhenAdapter.ts
+++ b/src/services/MarkwhenAdapter.ts
@@ -16,6 +16,7 @@ import {
   TimelineGroupBy,
   TimelineSectionsBy,
   TimelineColorBy,
+  TimelineDateLabel,
   PathMapping,
   EventPath,
   Recurrence,
@@ -75,6 +76,7 @@ export interface AdapterOptions {
   dateStartField: string;
   dateEndField: string;
   titleField: string;
+  dateLabel?: TimelineDateLabel;
 }
 
 /**
@@ -108,6 +110,7 @@ export class MarkwhenAdapter {
   private settings: PlannerSettings;
   private app: App;
   private pathMappings: PathMapping[] = [];
+  private currentDateLabel: TimelineDateLabel = 'start';
 
   constructor(settings: PlannerSettings, app: App) {
     this.settings = settings;
@@ -119,6 +122,7 @@ export class MarkwhenAdapter {
    */
   adapt(entries: BasesEntry[], options: AdapterOptions): AdaptedResult {
     this.pathMappings = [];
+    this.currentDateLabel = options.dateLabel || 'start';
 
     // Convert entries to timeline events
     const timelineEvents = this.entriesToTimelineEvents(entries, options);
@@ -714,7 +718,11 @@ export class MarkwhenAdapter {
    * Convert a TimelineEvent to a Markwhen Event
    */
   private timelineEventToMarkwhenEvent(event: TimelineEvent): Event {
-    const datePart = event.dateRangeIso.fromDateTimeIso.split('T')[0];
+    const labelIso =
+      this.currentDateLabel === 'end'
+        ? event.dateRangeIso.toDateTimeIso || event.dateRangeIso.fromDateTimeIso
+        : event.dateRangeIso.fromDateTimeIso;
+    const datePart = labelIso.split('T')[0];
 
     // Create a minimal Event object that Markwhen Timeline can render
     const mwEvent: Event = {

--- a/src/services/MarkwhenAdapter.ts
+++ b/src/services/MarkwhenAdapter.ts
@@ -25,6 +25,28 @@ import type { PlannerSettings } from '../types/settings';
 import type { PlannerItem, DayOfWeek } from '../types/item';
 
 /**
+ * Replace Obsidian wikilinks in a string with their display text:
+ *   [[target|alias]] → alias
+ *   [[target]]       → basename of target (no .md extension)
+ *   [[folder/file]]  → file
+ * Leaves any surrounding text intact. Useful when a timeline title comes
+ * from a formula that concatenates link-typed properties (e.g. a
+ * "Name · status · assignee" title built in a .base file), which would
+ * otherwise render as `Name · status · [[Pablo]]` in the Markwhen
+ * timeline UI.
+ */
+function cleanWikilinks(text: string): string {
+  return text.replace(
+    /\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/g,
+    (_match, target: string, alias?: string) => {
+      if (alias) return alias;
+      const basename = target.split('/').pop() ?? target;
+      return basename.replace(/\.md$/, '');
+    }
+  );
+}
+
+/**
  * Safely convert any value to a string, handling objects properly
  * Avoids [object Object] output for complex types
  */
@@ -304,8 +326,12 @@ export class MarkwhenAdapter {
     // Parse end date - default to start date if not set
     const endDate = this.parseDate(endValue) || startDate;
 
-    // Get title
-    const title = titleValue?.toString() || entry.file.basename;
+    // Get title. Apply cleanWikilinks so that link-typed values embedded
+    // in the title (directly or via a formula) render as display text
+    // rather than raw [[...]] syntax.
+    const title = cleanWikilinks(
+      titleValue?.toString() || entry.file.basename
+    );
 
     // Get tags from note
     const tagsValue = entry.getValue('note.tags');

--- a/src/services/MarkwhenAdapter.ts
+++ b/src/services/MarkwhenAdapter.ts
@@ -474,10 +474,10 @@ export class MarkwhenAdapter {
 
     if (Array.isArray(value)) {
       const firstVal: unknown = value[0];
-      return firstVal ? safeToString(firstVal).replace(/^#/, '') : 'Unsectioned';
+      return firstVal ? cleanWikilinks(safeToString(firstVal).replace(/^#/, '')) : 'Unsectioned';
     }
 
-    return safeToString(value);
+    return cleanWikilinks(safeToString(value));
   }
 
   /**
@@ -513,10 +513,10 @@ export class MarkwhenAdapter {
 
     if (Array.isArray(value)) {
       const firstVal: unknown = value[0];
-      return firstVal ? safeToString(firstVal).replace(/^#/, '') : 'Ungrouped';
+      return firstVal ? cleanWikilinks(safeToString(firstVal).replace(/^#/, '')) : 'Ungrouped';
     }
 
-    return safeToString(value);
+    return cleanWikilinks(safeToString(value));
   }
 
   /**
@@ -537,10 +537,10 @@ export class MarkwhenAdapter {
 
     if (Array.isArray(value)) {
       const firstVal: unknown = value[0];
-      return firstVal ? safeToString(firstVal).replace(/^#/, '') : undefined;
+      return firstVal ? cleanWikilinks(safeToString(firstVal).replace(/^#/, '')) : undefined;
     }
 
-    return safeToString(value);
+    return cleanWikilinks(safeToString(value));
   }
 
   /**

--- a/src/services/MarkwhenAdapter.ts
+++ b/src/services/MarkwhenAdapter.ts
@@ -823,11 +823,11 @@ export class MarkwhenAdapter {
           if (Array.isArray(value)) {
             const first: unknown = value[0];
             if (first) {
-              const firstVal = safeToString(first).replace(/^#/, '');
+              const firstVal = cleanWikilinks(safeToString(first).replace(/^#/, ''));
               if (firstVal) uniqueValues.add(firstVal);
             }
           } else {
-            uniqueValues.add(safeToString(value));
+            uniqueValues.add(cleanWikilinks(safeToString(value)));
           }
         }
       }

--- a/src/types/markwhen.ts
+++ b/src/types/markwhen.ts
@@ -209,6 +209,8 @@ export type TimelineSectionsBy = string;
 
 export type TimelineColorBy = string;
 
+export type TimelineDateLabel = 'start' | 'end';
+
 export interface TimelineViewConfig {
   groupBy: TimelineGroupBy;
   sectionsBy: TimelineSectionsBy;
@@ -216,6 +218,7 @@ export interface TimelineViewConfig {
   dateStartField: string;
   dateEndField: string;
   titleField: string;
+  dateLabel: TimelineDateLabel;
 }
 
 /**

--- a/src/views/BasesTimelineView.ts
+++ b/src/views/BasesTimelineView.ts
@@ -22,6 +22,7 @@ import {
   TimelineGroupBy,
   TimelineSectionsBy,
   TimelineColorBy,
+  TimelineDateLabel,
   MarkwhenState,
   AppState,
   EditEventDateRangeMessage,
@@ -88,6 +89,11 @@ export class BasesTimelineView extends BasesView {
   private getTitleField(): string {
     const value = this.config?.get('titleField') as string | undefined;
     return value || 'note.title';
+  }
+
+  private getDateLabel(): TimelineDateLabel {
+    const value = this.config?.get('dateLabel') as string | undefined;
+    return value === 'end' ? 'end' : 'start';
   }
 
   private getBackgroundColor(): string | undefined {
@@ -251,6 +257,7 @@ export class BasesTimelineView extends BasesView {
       dateStartField: this.getDateStartField(),
       dateEndField: this.getDateEndField(),
       titleField: this.getTitleField(),
+      dateLabel: this.getDateLabel(),
     };
 
     // Adapt entries to Markwhen format
@@ -488,6 +495,16 @@ export function createTimelineViewRegistration(plugin: PlannerPlugin): BasesView
         placeholder: 'Select property',
         filter: (propId: BasesPropertyId) =>
           PropertyTypeService.isTextProperty(propId, plugin.app),
+      },
+      {
+        type: 'dropdown',
+        key: 'dateLabel',
+        displayName: 'Date label',
+        default: 'start',
+        options: {
+          'start': 'Start date',
+          'end': 'End date',
+        },
       },
       {
         type: 'dropdown',


### PR DESCRIPTION
## Problem

The `planner-timeline` view hardcodes the event's start date as the label next to each bar (via `datePart` in `MarkwhenAdapter.timelineEventToMarkwhenEvent`, which always reads `event.dateRangeIso.fromDateTimeIso`). For vaults that track both a start and an end field, many workflows care more about the end date (deadlines, due-dates, fin previsto) than the start.

Example `.base` where this matters:

```yaml
views:
  - type: planner-timeline
    dateStartField: note.fecha_inicio
    dateEndField: note.fecha_fin_prevista
    titleField: formula.full_title
```

The bar itself spans from start to end correctly, but the text label on the left always shows the start date and there is no way to switch it.

## Change

Adds a new view option `dateLabel` with two values:

- `start` (default): preserves the current behavior.
- `end`: uses `event.dateRangeIso.toDateTimeIso` for the displayed label, falling back to `fromDateTimeIso` if absent.

Plumbing:

- New `TimelineDateLabel` type in `src/types/markwhen.ts` and a `dateLabel` field on `TimelineViewConfig`.
- Extended `AdapterOptions` with optional `dateLabel`. `MarkwhenAdapter` stores it on the instance at `adapt()` time so `timelineEventToMarkwhenEvent` can read it without threading a new parameter through every intermediate call.
- `BasesTimelineView` reads the config via `getDateLabel()`, passes it to the adapter, and registers a `dropdown` option in the view schema next to `titleField`.

## Testing

Manually tested with a real `.base` that has `fecha_inicio` and `fecha_fin_prevista`:
- Default (no `dateLabel` set or `dateLabel: start`): same output as before.
- `dateLabel: end`: labels swap to the end date, bars unchanged, edit-drag handles still work.
- Events with only a start date: falls back gracefully (no empty label).